### PR TITLE
Release/0.29 stable

### DIFF
--- a/app/cells/concerns/decidim/homepage_proposals/admin/content_block_cell_customization.rb
+++ b/app/cells/concerns/decidim/homepage_proposals/admin/content_block_cell_customization.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Decidim
+  module HomepageProposals
+    module Admin
+      module ContentBlockCellCustomization
+        extend ActiveSupport::Concern
+
+        included do
+          alias_method :decidim_name, :name
+
+          def name
+            attribute_name = custom_title_attribute
+            return decidim_name if attribute_name.blank?
+
+            [decidim_name, translated_attribute(model.settings.send(attribute_name)).presence].compact.join(" - ")
+          end
+
+          private
+
+          def custom_title_attribute
+            return unless has_settings?
+            return if model.settings_form_cell.blank?
+
+            cell = Decidim::ViewModel.cell(model.settings_form_cell)
+            return unless cell.respond_to?(:content_block_name_attribute)
+
+            cell.content_block_name_attribute
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider/content.erb
+++ b/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider/content.erb
@@ -2,6 +2,12 @@
   <h2 class="home__section-title">
     <%= title %>
   </h2>
+  <% if view_all_url_config.present? %>
+    <%= link_to view_all_url_config, class: "button button__sm button__text-secondary", data: { view_all_link: model.id }  do %>
+      <%= view_all_text_config %>
+      <%= icon "arrow-right-line", class: "fill-current" %>
+    <% end %>
+  <% end %>
 </div>
 <div class="filters_container" <%= 'style="display: none"' unless settings.activate_filters %>>
   <%= filters %>

--- a/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider/content.erb
+++ b/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider/content.erb
@@ -4,7 +4,7 @@
   </h2>
 </div>
 <div class="filters_container" <%= 'style="display: none"' unless settings.activate_filters %>>
-  <%= render partial: "decidim/shared/homepage_proposals/filters" %>
+  <%= filters %>
 </div>
 <div id="<%= "proposals-slider-#{model.id}" %>">
   <div class="glide margin-top-3">

--- a/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider/filters.erb
+++ b/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider/filters.erb
@@ -1,0 +1,1 @@
+<%= render partial: "decidim/shared/homepage_proposals/filters" %>

--- a/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_cell.rb
+++ b/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_cell.rb
@@ -44,11 +44,21 @@ module Decidim
         end
 
         def categories_filter
-          @categories_filter ||= Decidim::Category.where(id: linked_components.map(&:categories).flatten)
+          @categories_filter ||= Decidim::Category.where(id: available_categories_ids)
         end
 
         def selected_component_id
           @selected_component_id ||= params.dig(:filter, :component_id) || settings.default_linked_component
+        end
+
+        def selected_category_id
+          params.dig(:filter, :category_id)&.to_i
+        end
+
+        def available_categories_ids
+          categories_ids = base_proposals_relation.joins(:category).select("decidim_categorizations.decidim_category_id").distinct.map(&:decidim_category_id)
+          categories_ids << selected_category_id if selected_category_id.present? && categories_ids.exclude?(selected_category_id)
+          categories_ids
         end
 
         def order_config
@@ -77,6 +87,10 @@ module Decidim
 
         def data
           { proposals_slider: model.id }
+        end
+
+        def base_proposals_relation
+          Decidim::Proposals::Proposal.not_status(:rejected).not_withdrawn.published.where(component: selected_component_id)
         end
       end
     end

--- a/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_cell.rb
+++ b/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_cell.rb
@@ -59,6 +59,18 @@ module Decidim
           settings.max_results.presence || 12
         end
 
+        def view_all_text_config
+          translated_attribute(settings.view_all_text).presence || I18n.t("decidim.homepage_proposals.proposal_at_a_glance.filters.all_proposals")
+        end
+
+        def view_all_url_config
+          return default_linked_component_path if settings.view_all_url.blank?
+
+          URI.parse(settings.view_all_url).to_s
+        rescue URI::InvalidURIError
+          default_linked_component_path
+        end
+
         def title
           translated_attribute(settings.block_title).presence || I18n.t("decidim.homepage_proposals.proposal_at_a_glance.title")
         end

--- a/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_cell.rb
+++ b/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_cell.rb
@@ -18,9 +18,9 @@ module Decidim
         include Decidim::ScopesHelper
 
         def default_linked_component_path
+          return unless Decidim::Component.exists?(selected_component_id)
+
           main_component_path(Decidim::Component.find(selected_component_id))
-        rescue ActiveRecord::RecordNotFound
-          root_path
         end
 
         def options_for_default_component

--- a/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_cell.rb
+++ b/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_cell.rb
@@ -59,10 +59,28 @@ module Decidim
           params.dig(:filter, :category_id)&.to_i
         end
 
+        def selected_scope_id
+          params.dig(:filter, :category_id)&.to_i
+        end
+
         def available_categories_ids
           categories_ids = base_proposals_relation.joins(:category).select("decidim_categorizations.decidim_category_id").distinct.map(&:decidim_category_id)
           categories_ids << selected_category_id if selected_category_id.present? && categories_ids.exclude?(selected_category_id)
           categories_ids
+        end
+
+        def available_scopes_ids
+          @available_scopes_ids ||= begin
+            scopes_ids = base_proposals_relation.joins(:scope).pluck("decidim_scope_id").uniq
+            scopes_ids << selected_scope_id if selected_scope_id.present? && scopees_ids.exclude?(selected_scope_id)
+            scopes_ids
+          end
+        end
+
+        def scopes_for_select
+          Decidim::Scope.where(id: available_scopes_ids).sort { |a, b| a.part_of.reverse <=> b.part_of.reverse }.map do |scope|
+            [" #{"&nbsp;" * 4 * (scope.part_of.count - 1)} #{translated_attribute(scope.name)}".html_safe, scope&.id]
+          end
         end
 
         def order_config

--- a/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_cell.rb
+++ b/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_cell.rb
@@ -85,6 +85,14 @@ module Decidim
           default_linked_component_path
         end
 
+        def display_config
+          @display_config ||= {
+            state: settings.display_proposals_state,
+            description: settings.display_proposals_description,
+            image: settings.display_proposals_image
+          }
+        end
+
         def title
           translated_attribute(settings.block_title).presence || I18n.t("decidim.homepage_proposals.proposal_at_a_glance.title")
         end

--- a/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_cell.rb
+++ b/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_cell.rb
@@ -94,7 +94,21 @@ module Decidim
         end
 
         def base_proposals_relation
-          Decidim::Proposals::Proposal.not_status(:rejected).not_withdrawn.published.where(component: selected_component_id)
+          proposals_with_state_not_rejected.or(proposals_without_state_not_answered)
+        end
+
+        def proposals_with_state_not_rejected
+          base_proposals_join.where.not(decidim_proposals_proposal_states: { token: :rejected })
+        end
+
+        def proposals_without_state_not_answered
+          base_proposals_join.where(decidim_proposals_proposal_state_id: nil, answered_at: nil)
+        end
+
+        def base_proposals_join
+          Decidim::Proposals::Proposal
+            .not_withdrawn.published.where(component: selected_component_id)
+            .left_outer_joins(:proposal_state)
         end
       end
     end

--- a/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_cell.rb
+++ b/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_cell.rb
@@ -85,14 +85,6 @@ module Decidim
           default_linked_component_path
         end
 
-        def display_config
-          @display_config ||= {
-            state: settings.display_proposals_state,
-            body: settings.display_proposals_body,
-            image: settings.display_proposals_image
-          }
-        end
-
         def title
           translated_attribute(settings.block_title).presence || I18n.t("decidim.homepage_proposals.proposal_at_a_glance.title")
         end

--- a/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_cell.rb
+++ b/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_cell.rb
@@ -88,7 +88,7 @@ module Decidim
         def display_config
           @display_config ||= {
             state: settings.display_proposals_state,
-            description: settings.display_proposals_description,
+            body: settings.display_proposals_body,
             image: settings.display_proposals_image
           }
         end

--- a/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_cell.rb
+++ b/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_cell.rb
@@ -47,6 +47,10 @@ module Decidim
           @categories_filter ||= Decidim::Category.where(id: available_categories_ids)
         end
 
+        def filters
+          render :filters
+        end
+
         def selected_component_id
           @selected_component_id ||= params.dig(:filter, :component_id) || settings.default_linked_component
         end

--- a/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_cell.rb
+++ b/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_cell.rb
@@ -94,21 +94,7 @@ module Decidim
         end
 
         def base_proposals_relation
-          proposals_with_state_not_rejected.or(proposals_without_state_not_answered)
-        end
-
-        def proposals_with_state_not_rejected
-          base_proposals_join.where.not(decidim_proposals_proposal_states: { token: :rejected })
-        end
-
-        def proposals_without_state_not_answered
-          base_proposals_join.where(decidim_proposals_proposal_state_id: nil, answered_at: nil)
-        end
-
-        def base_proposals_join
-          Decidim::Proposals::Proposal
-            .not_withdrawn.published.where(component: selected_component_id)
-            .left_outer_joins(:proposal_state)
+          Decidim::Proposals::SliderProposals.for(selected_component_id)
         end
       end
     end

--- a/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_settings_form/show.erb
+++ b/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_settings_form/show.erb
@@ -37,4 +37,12 @@
   <div class="row column">
     <%= settings_fields.translated :text_field, :block_title, label: t(".block_title") %>
   </div>
+
+  <div class="row column">
+    <%= settings_fields.translated :text_field, :view_all_text, label: t(".view_all_text") %>
+  </div>
+
+  <div class="row column">
+    <%= settings_fields.text_field :view_all_url, label: t(".view_all_url") %>
+  </div>
 <% end %>

--- a/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_settings_form/show.erb
+++ b/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_settings_form/show.erb
@@ -22,7 +22,7 @@
   <div class="row column" data-default-linked-component-row <%= 'style="display: none"' if hide_default_component_select? %>>
     <%= settings_fields.select :default_linked_component,
                    options_for_default_component,
-                   { include_blank: false, label: t(".default_linked_component") },
+                   { include_blank: false, label: t(".default_linked_component"), help_text: t(".activate_filters_help")},
                    class: "chosen-select" %>
   </div>
 

--- a/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_settings_form/show.erb
+++ b/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_settings_form/show.erb
@@ -1,14 +1,40 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.check_box :activate_filters, label: t(".activate_filters") %>
-  <%= settings_fields.select :linked_components_id,
-                             options_for_proposals_components,
-                             { include_blank: true, label: t(".linked_components_id") },
-                             { multiple: true, class: "chosen-select" } %>
-  <%= settings_fields.select :default_linked_component,
-                 options_for_default_component,
-                 { include_blank: false, label: t(".default_linked_component") },
-                 class: "chosen-select" %>
-  <%= settings_fields.select :order, order_options, prompt: "", label: t(".order") %>
-  <%= settings_fields.select :max_results, [*(4..12)], prompt: "", label: t(".max_results") %>
-  <%= settings_fields.translated :text_field, :block_title, label: t(".block_title") %>
+  <div class="row column">
+    <%= settings_fields.check_box :activate_filters, label: t(".activate_filters") %>
+  </div>
+
+  <div class="row column">
+    <label><%= t(".linked_components_id") %></label>
+    <%= hidden_field_tag("content_block[settings][linked_components_id][]") %>
+    <%= select_tag(
+          "content_block[settings][linked_components_id]",
+          options_for_proposals_components,
+          {
+            label: t(".linked_components_id"),
+            include_blank: true,
+            placeholder: t(".select_components"),
+            class: "chosen-select js-linked-components-multiselect",
+            multiple: true
+          }
+        ) %>
+  </div>
+
+  <div class="row column">
+    <%= settings_fields.select :default_linked_component,
+                   options_for_default_component,
+                   { include_blank: false, label: t(".default_linked_component") },
+                   class: "chosen-select" %>
+  </div>
+
+  <div class="row column">
+    <%= settings_fields.select :order, order_options, prompt: "", label: t(".order") %>
+  </div>
+
+  <div class="row column">
+    <%= settings_fields.select :max_results, [*(4..12)], prompt: "", label: t(".max_results") %>
+  </div>
+
+  <div class="row column">
+    <%= settings_fields.translated :text_field, :block_title, label: t(".block_title") %>
+  </div>
 <% end %>

--- a/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_settings_form/show.erb
+++ b/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_settings_form/show.erb
@@ -1,6 +1,6 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
   <div class="row column">
-    <%= settings_fields.check_box :activate_filters, label: t(".activate_filters") %>
+    <%= settings_fields.check_box :activate_filters, label: t("activate_filters", scope: "decidim.homepage_proposals.content_blocks.proposals_slider_settings_form") %>
   </div>
 
   <div class="row column">
@@ -12,7 +12,7 @@
           {
             label: t(".linked_components_id"),
             include_blank: true,
-            placeholder: t(".select_components"),
+            placeholder: t("select_components", scope: "decidim.homepage_proposals.content_blocks.proposals_slider_settings_form"),
             class: "chosen-select js-linked-components-multiselect",
             multiple: true
           }
@@ -22,7 +22,7 @@
   <div class="row column" data-default-linked-component-row <%= 'style="display: none"' if hide_default_component_select? %>>
     <%= settings_fields.select :default_linked_component,
                    options_for_default_component,
-                   { include_blank: false, label: t(".default_linked_component"), help_text: t(".activate_filters_help")},
+                   { include_blank: false, label: t(".default_linked_component"), help_text: t("activate_filters_help", scope: "decidim.homepage_proposals.content_blocks.proposals_slider_settings_form")},
                    class: "chosen-select" %>
   </div>
 
@@ -39,30 +39,30 @@
   </div>
 
   <div class="row column">
-    <%= settings_fields.translated :text_field, :view_all_text, label: t(".view_all_text") %>
+    <%= settings_fields.translated :text_field, :view_all_text, label: t("view_all_text", scope: "decidim.homepage_proposals.content_blocks.proposals_slider_settings_form") %>
   </div>
 
   <div class="row column">
-    <%= settings_fields.text_field :view_all_url, label: t(".view_all_url") %>
+    <%= settings_fields.text_field :view_all_url, label: t("view_all_url", scope: "decidim.homepage_proposals.content_blocks.proposals_slider_settings_form") %>
   </div>
 
   <div class="row column">
-    <%= settings_fields.number_field :max_length_of_title, label: t(".max_length_of_title") %>
+    <%= settings_fields.number_field :max_length_of_title, label: t("max_length_of_title", scope: "decidim.homepage_proposals.content_blocks.proposals_slider_settings_form") %>
   </div>
 
   <div class="row column">
-    <%= settings_fields.number_field :max_length_of_body, label: t(".max_length_of_body") %>
+    <%= settings_fields.number_field :max_length_of_body, label: t("max_length_of_body", scope: "decidim.homepage_proposals.content_blocks.proposals_slider_settings_form") %>
   </div>
 
   <div class="row column">
-    <%= settings_fields.check_box :display_proposals_state, label: t(".display_proposals_state") %>
+    <%= settings_fields.check_box :display_proposals_state, label: t("display_proposals_state", scope: "decidim.homepage_proposals.content_blocks.proposals_slider_settings_form") %>
   </div>
 
   <div class="row column">
-    <%= settings_fields.check_box :display_proposals_body, label: t(".display_proposals_body") %>
+    <%= settings_fields.check_box :display_proposals_body, label: t("display_proposals_body", scope: "decidim.homepage_proposals.content_blocks.proposals_slider_settings_form") %>
   </div>
 
   <div class="row column">
-    <%= settings_fields.check_box :display_proposals_image, label: t(".display_proposals_image") %>
+    <%= settings_fields.check_box :display_proposals_image, label: t("display_proposals_image", scope: "decidim.homepage_proposals.content_blocks.proposals_slider_settings_form") %>
   </div>
 <% end %>

--- a/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_settings_form/show.erb
+++ b/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_settings_form/show.erb
@@ -47,6 +47,14 @@
   </div>
 
   <div class="row column">
+    <%= settings_fields.number_field :max_length_of_title, label: t(".max_length_of_title") %>
+  </div>
+
+  <div class="row column">
+    <%= settings_fields.number_field :max_length_of_body, label: t(".max_length_of_body") %>
+  </div>
+
+  <div class="row column">
     <%= settings_fields.check_box :display_proposals_state, label: t(".display_proposals_state") %>
   </div>
 

--- a/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_settings_form/show.erb
+++ b/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_settings_form/show.erb
@@ -45,4 +45,16 @@
   <div class="row column">
     <%= settings_fields.text_field :view_all_url, label: t(".view_all_url") %>
   </div>
+
+  <div class="row column">
+    <%= settings_fields.check_box :display_proposals_state, label: t(".display_proposals_state") %>
+  </div>
+
+  <div class="row column">
+    <%= settings_fields.check_box :display_proposals_description, label: t(".display_proposals_description") %>
+  </div>
+
+  <div class="row column">
+    <%= settings_fields.check_box :display_proposals_image, label: t(".display_proposals_image") %>
+  </div>
 <% end %>

--- a/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_settings_form/show.erb
+++ b/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_settings_form/show.erb
@@ -59,7 +59,7 @@
   </div>
 
   <div class="row column">
-    <%= settings_fields.check_box :display_proposals_description, label: t(".display_proposals_description") %>
+    <%= settings_fields.check_box :display_proposals_body, label: t(".display_proposals_body") %>
   </div>
 
   <div class="row column">

--- a/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_settings_form/show.erb
+++ b/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_settings_form/show.erb
@@ -19,7 +19,7 @@
         ) %>
   </div>
 
-  <div class="row column">
+  <div class="row column" data-default-linked-component-row <%= 'style="display: none"' if hide_default_component_select? %>>
     <%= settings_fields.select :default_linked_component,
                    options_for_default_component,
                    { include_blank: false, label: t(".default_linked_component") },

--- a/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_settings_form_cell.rb
+++ b/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_settings_form_cell.rb
@@ -28,7 +28,11 @@ module Decidim
         end
 
         def proposals_components
-          @proposals_components ||= Decidim::PublicComponents.for(content_block.organization, manifest_name: "proposals")
+          @proposals_components ||= if public_proposals.exists?
+                                      Decidim::Component.where(id: public_proposals.select(:decidim_component_id).distinct)
+                                    else
+                                      Decidim::PublicComponents.for(content_block.organization, manifest_name: "proposals")
+                                    end
         end
 
         def order_options
@@ -37,6 +41,14 @@ module Decidim
             [I18n.t("least_recent", scope: "decidim.homepage_proposals.content_blocks.proposals_slider_settings_form.show"), "least_recent"],
             [I18n.t("random", scope: "decidim.homepage_proposals.content_blocks.proposals_slider_settings_form.show"), "random"]
           ]
+        end
+
+        private
+
+        def public_proposals
+          @public_proposals ||= Decidim::Proposals::FilteredProposals.for(
+            Decidim::PublicComponents.for(content_block.organization, manifest_name: "proposals")
+          ).not_status(:rejected).not_withdrawn.published
         end
       end
     end

--- a/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_settings_form_cell.rb
+++ b/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_settings_form_cell.rb
@@ -5,6 +5,7 @@ module Decidim
     module ContentBlocks
       class ProposalsSliderSettingsFormCell < Decidim::ViewModel
         include ActionView::Helpers::FormOptionsHelper
+        include Decidim::ContentBlocks::HasRelatedComponents
 
         alias form model
 
@@ -29,9 +30,9 @@ module Decidim
 
         def proposals_components
           @proposals_components ||= if public_proposals.exists?
-                                      Decidim::Component.where(id: public_proposals.select(:decidim_component_id).distinct)
+                                      components.where(id: public_proposals.select(:decidim_component_id).distinct)
                                     else
-                                      Decidim::PublicComponents.for(content_block.organization, manifest_name: "proposals")
+                                      components
                                     end
         end
 
@@ -50,9 +51,11 @@ module Decidim
         private
 
         def public_proposals
-          @public_proposals ||= Decidim::Proposals::FilteredProposals.for(
-            Decidim::PublicComponents.for(content_block.organization, manifest_name: "proposals")
-          ).not_status(:rejected).not_withdrawn.published
+          @public_proposals ||= Decidim::Proposals::FilteredProposals.for(components).not_status(:rejected).not_withdrawn.published
+        end
+
+        def components
+          @components ||= components_for(content_block).published
         end
       end
     end

--- a/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_settings_form_cell.rb
+++ b/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_settings_form_cell.rb
@@ -59,7 +59,21 @@ module Decidim
         end
 
         def public_proposals
-          @public_proposals ||= Decidim::Proposals::FilteredProposals.for(components).not_status(:rejected).not_withdrawn.published
+          @public_proposals ||= proposals_with_state_not_rejected.or(proposals_without_state_not_answered)
+        end
+
+        def proposals_with_state_not_rejected
+          base_proposals_join.where.not(decidim_proposals_proposal_states: { token: :rejected })
+        end
+
+        def proposals_without_state_not_answered
+          base_proposals_join.where(decidim_proposals_proposal_state_id: nil, answered_at: nil)
+        end
+
+        def base_proposals_join
+          Decidim::Proposals::FilteredProposals
+            .for(components).not_withdrawn.published
+            .left_outer_joins(:proposal_state)
         end
 
         def components

--- a/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_settings_form_cell.rb
+++ b/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_settings_form_cell.rb
@@ -21,7 +21,7 @@ module Decidim
         end
 
         def options_for_default_component
-          components = Decidim::Component.where(id: content_block.settings.linked_components_id.compact)
+          components = Decidim::Component.where(id: selectable_default_component_ids)
           options = components.map do |component|
             ["#{translated_attribute(component.name)} (#{translated_attribute(component.participatory_space.title)})", component.id]
           end
@@ -48,7 +48,15 @@ module Decidim
           :block_title
         end
 
+        def hide_default_component_select?
+          selectable_default_component_ids.count < 2
+        end
+
         private
+
+        def selectable_default_component_ids
+          @selectable_default_component_ids ||= content_block.settings.linked_components_id.compact_blank
+        end
 
         def public_proposals
           @public_proposals ||= Decidim::Proposals::FilteredProposals.for(components).not_status(:rejected).not_withdrawn.published

--- a/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_settings_form_cell.rb
+++ b/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_settings_form_cell.rb
@@ -43,6 +43,10 @@ module Decidim
           ]
         end
 
+        def content_block_name_attribute
+          :block_title
+        end
+
         private
 
         def public_proposals

--- a/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_settings_form_cell.rb
+++ b/app/cells/decidim/homepage_proposals/content_blocks/proposals_slider_settings_form_cell.rb
@@ -59,21 +59,7 @@ module Decidim
         end
 
         def public_proposals
-          @public_proposals ||= proposals_with_state_not_rejected.or(proposals_without_state_not_answered)
-        end
-
-        def proposals_with_state_not_rejected
-          base_proposals_join.where.not(decidim_proposals_proposal_states: { token: :rejected })
-        end
-
-        def proposals_without_state_not_answered
-          base_proposals_join.where(decidim_proposals_proposal_state_id: nil, answered_at: nil)
-        end
-
-        def base_proposals_join
-          Decidim::Proposals::FilteredProposals
-            .for(components).not_withdrawn.published
-            .left_outer_joins(:proposal_state)
+          @public_proposals ||= Decidim::Proposals::SliderProposals.for(components)
         end
 
         def components

--- a/app/controllers/decidim/proposals_slider_controller.rb
+++ b/app/controllers/decidim/proposals_slider_controller.rb
@@ -47,15 +47,23 @@ module Decidim
     def build_proposals_api
       return component_url unless glanced_proposals.any?
 
+      display_body = content_block&.settings.present? ? content_block.settings.display_proposals_body : true
+      display_image = content_block&.settings.present? ? content_block.settings.display_proposals_image : true
+      display_state = content_block&.settings.present? ? content_block.settings.display_proposals_state : true
+
       glanced_proposals.flat_map do |proposal|
-        {
+        data =  {
           id: proposal.id,
           title: title_for(proposal),
-          body: body_for(proposal),
           url: proposal_path(proposal),
-          image: image_for(proposal),
           tags: proposal.category ? cell("decidim/homepage_proposals/tags", proposal).to_s.strip.html_safe : ""
-        }.merge(state_settings(proposal))
+        }
+
+        data.merge!(body: body_for(proposal)) if display_body
+        data.merge!(image: image_for(proposal)) if display_image
+        data.merge!(state_settings(proposal)) if display_state
+
+        data
       end
     end
 

--- a/app/controllers/decidim/proposals_slider_controller.rb
+++ b/app/controllers/decidim/proposals_slider_controller.rb
@@ -80,7 +80,7 @@ module Decidim
     end
 
     def base_query(component:, scopes: nil, category: nil)
-      query = Decidim::Proposals::Proposal.not_status(:rejected).not_withdrawn.published.where(component:).where(filter_by_scopes(scopes))
+      query = Decidim::Proposals::SliderProposals.for(component).where(filter_by_scopes(scopes))
       return query.with_category(category) if category.present?
 
       query

--- a/app/controllers/decidim/proposals_slider_controller.rb
+++ b/app/controllers/decidim/proposals_slider_controller.rb
@@ -68,14 +68,14 @@ module Decidim
     end
 
     def glanced_proposals
-      if params[:filter].present?
-        category = Decidim::Category.find(params.dig(:filter, :category_id)) if params.dig(:filter, :category_id).present?
-        scopes = Decidim::Scope.find(params.dig(:filter, :scope_id)) if params.dig(:filter, :scope_id).present?
+      if filter_params.present?
+        category = Decidim::Category.find(filter_params[:category_id]) if filter_params[:category_id].present?
+        scopes = Decidim::Scope.find(filter_params[:scope_id]) if filter_params[:scope_id].present?
       end
 
       @glanced_proposals ||= sorted_query(
-        base_query(component: params.dig(:filter, :component_id), category:, scopes:),
-        **filter_config
+        base_query(component: components_ids, category:, scopes:),
+        **filter_config.except(:content_block)
       )
     end
 
@@ -103,7 +103,7 @@ module Decidim
     end
 
     def filter_config
-      @filter_config ||= { "order" => "random", "max_results" => 12 }.merge(params[:filter_config]&.permit(:order, :max_results).to_h).symbolize_keys
+      @filter_config ||= { "order" => "random", "max_results" => 12 }.merge(params[:filter_config]&.permit(:order, :max_results, :content_block).to_h).symbolize_keys
     end
 
     def proposal_path(proposal)
@@ -131,7 +131,7 @@ module Decidim
     end
 
     def set_content_block
-      @content_block = Decidim::ContentBlock.find_by(id: params[:filter_config][:content_block])
+      @content_block = Decidim::ContentBlock.find_by(id: filter_config[:content_block])
     end
 
     def title_max_length
@@ -150,6 +150,14 @@ module Decidim
       rescue ActiveRecord::RecordNotFound
         { url: "/" }
       end
+    end
+
+    def components_ids
+      @components_ids ||= filter_params[:component_id] || content_block.settings.linked_components_id&.compact_blank
+    end
+
+    def filter_params
+      @filter_params ||= params[:filter].present? ? params.require(:filter).permit(:component_id, :content_block, :category_id, :scope_id) : {}
     end
   end
 end

--- a/app/controllers/decidim/proposals_slider_controller.rb
+++ b/app/controllers/decidim/proposals_slider_controller.rb
@@ -7,6 +7,7 @@ module Decidim
     include Decidim::Core::Engine.routes.url_helpers
     include Decidim::ComponentPathHelper
     include Decidim::LayoutHelper
+    include Decidim::Proposals::ApplicationHelper
 
     delegate :asset_pack_path, to: :action_controller_helpers
     def refresh_proposals
@@ -19,23 +20,6 @@ module Decidim
       ActionController::Base.helpers
     end
 
-    def proposal_state_css_class(proposal)
-      return if proposal.state.blank?
-      return proposal.proposal_state&.css_class if proposal.respond_to?(:proposal_state) && !roposal.emendation?
-      return "info" unless proposal.published_state?
-
-      case proposal.state
-      when "accepted"
-        "success"
-      when "rejected", "withdrawn"
-        "alert"
-      when "evaluating"
-        "warning"
-      else
-        "info"
-      end
-    end
-
     def proposal_complete_state(proposal)
       return humanize_proposal_state(proposal.state) unless proposal.respond_to?(:proposal_state)
       return humanize_proposal_state("not_answered").html_safe if proposal.proposal_state.nil?
@@ -44,21 +28,11 @@ module Decidim
       translated_attribute(proposal&.proposal_state&.title)
     end
 
-    def humanize_proposal_state(state)
-      I18n.t(state, scope: "decidim.proposals.answers", default: :not_answered)
-    end
-
     def state_settings(proposal)
-      state_18n = if Decidim.module_installed?(:custom_proposal_states) || proposal.respond_to?(:proposal_state)
-                    proposal_complete_state(proposal)
-                  else
-                    humanize_proposal_state(proposal.state)
-                   end
-
       {
-        state: proposal.state,
+        state_i18n: proposal_complete_state(proposal),
         state_css_class: proposal_state_css_class(proposal),
-        state_i18n: state_18n
+        state_css_style: proposal_state_css_style(proposal)
       }
     end
 

--- a/app/controllers/decidim/proposals_slider_controller.rb
+++ b/app/controllers/decidim/proposals_slider_controller.rb
@@ -10,13 +10,15 @@ module Decidim
     include Decidim::Proposals::ApplicationHelper
 
     delegate :asset_pack_path, to: :action_controller_helpers
+    attr_reader :content_block
+
+    before_action :set_content_block
+
     def refresh_proposals
       render json: build_proposals_api
     end
 
     def filters
-      @content_block = Decidim::ContentBlock.find params[:filter_config][:content_block]
-
       render layout: false
     end
 
@@ -48,8 +50,8 @@ module Decidim
       glanced_proposals.flat_map do |proposal|
         {
           id: proposal.id,
-          title: translated_attribute(proposal.title).truncate(40),
-          body: Decidim::Proposals::ProposalPresenter.new(proposal).body(strip_tags: true).truncate(150),
+          title: title_for(proposal),
+          body: body_for(proposal),
           url: proposal_path(proposal),
           image: image_for(proposal),
           tags: proposal.category ? cell("decidim/homepage_proposals/tags", proposal).to_s.strip.html_safe : ""
@@ -104,6 +106,32 @@ module Decidim
       return external_icon("media/images/placeholder-card-g.svg", class: "card__placeholder-g").to_s unless proposal.attachments.select(&:image?).any?
 
       ActionController::Base.helpers.image_tag(proposal.attachments.select(&:image?).first&.url, class: "card__grid-img")
+    end
+
+    def title_for(proposal)
+      title = translated_attribute(proposal.title)
+      return title if title_max_length.zero?
+
+      title.truncate(title_max_length)
+    end
+
+    def body_for(proposal)
+      body = Decidim::Proposals::ProposalPresenter.new(proposal).body(strip_tags: true)
+      return body if body_max_length.zero?
+
+      body.truncate(body_max_length)
+    end
+
+    def set_content_block
+      @content_block = Decidim::ContentBlock.find_by(id: params[:filter_config][:content_block])
+    end
+
+    def title_max_length
+      @title_max_length ||= content_block&.settings&.max_length_of_title&.positive? ? content_block.settings.max_length_of_title : 0
+    end
+
+    def body_max_length
+      @body_max_length ||= content_block&.settings&.max_length_of_body&.positive? ? content_block.settings.max_length_of_body : 0
     end
 
     def component_url

--- a/app/controllers/decidim/proposals_slider_controller.rb
+++ b/app/controllers/decidim/proposals_slider_controller.rb
@@ -14,6 +14,12 @@ module Decidim
       render json: build_proposals_api
     end
 
+    def filters
+      @content_block = Decidim::ContentBlock.find params[:filter_config][:content_block]
+
+      render layout: false
+    end
+
     private
 
     def action_controller_helpers

--- a/app/controllers/decidim/proposals_slider_controller.rb
+++ b/app/controllers/decidim/proposals_slider_controller.rb
@@ -90,7 +90,7 @@ module Decidim
     end
 
     def base_query(component:, scopes: nil, category: nil)
-      query = Decidim::Proposals::Proposal.not_rejected.not_withdrawn.published.where(component:).where(filter_by_scopes(scopes))
+      query = Decidim::Proposals::Proposal.not_status(:rejected).not_withdrawn.published.where(component:).where(filter_by_scopes(scopes))
       return query.with_category(category) if category.present?
 
       query

--- a/app/overrides/decidim/participatory_processes/participatory_processes/show/append_javascript_pack.html.erb.deface
+++ b/app/overrides/decidim/participatory_processes/participatory_processes/show/append_javascript_pack.html.erb.deface
@@ -1,4 +1,3 @@
 <!-- insert_before "div.participatory-space__container" -->
 
-LLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLL
 <%= append_javascript_pack_tag("decidim_homepage_proposals") %>

--- a/app/overrides/decidim/participatory_processes/participatory_processes/show/append_javascript_pack.html.erb.deface
+++ b/app/overrides/decidim/participatory_processes/participatory_processes/show/append_javascript_pack.html.erb.deface
@@ -1,0 +1,4 @@
+<!-- insert_before "div.participatory-space__container" -->
+
+LLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLL
+<%= append_javascript_pack_tag("decidim_homepage_proposals") %>

--- a/app/overrides/layouts/decidim/admin/assemblies/append_javascript_pack.html.erb.deface
+++ b/app/overrides/layouts/decidim/admin/assemblies/append_javascript_pack.html.erb.deface
@@ -1,0 +1,4 @@
+<!-- insert_before "erb[loud]:contains('layouts/decidim/admin/application')" -->
+
+<%= append_stylesheet_pack_tag("decidim_homepage_proposals_admin") %>
+<%= append_javascript_pack_tag("decidim_homepage_proposals_admin") %>

--- a/app/overrides/layouts/decidim/admin/participatory_process/append_javascript_pack.html.erb.deface
+++ b/app/overrides/layouts/decidim/admin/participatory_process/append_javascript_pack.html.erb.deface
@@ -1,0 +1,4 @@
+<!-- insert_before "erb[loud]:contains('layouts/decidim/admin/application')" -->
+
+<%= append_stylesheet_pack_tag("decidim_homepage_proposals_admin") %>
+<%= append_javascript_pack_tag("decidim_homepage_proposals_admin") %>

--- a/app/overrides/layouts/decidim/admin/participatory_process_group/append_javascript_pack.html.erb.deface
+++ b/app/overrides/layouts/decidim/admin/participatory_process_group/append_javascript_pack.html.erb.deface
@@ -1,0 +1,4 @@
+<!-- insert_before "erb[loud]:contains('layouts/decidim/admin/application')" -->
+
+<%= append_stylesheet_pack_tag("decidim_homepage_proposals_admin") %>
+<%= append_javascript_pack_tag("decidim_homepage_proposals_admin") %>

--- a/app/overrides/layouts/decidim/admin/settings/append_javascript_pack.html.erb.deface
+++ b/app/overrides/layouts/decidim/admin/settings/append_javascript_pack.html.erb.deface
@@ -1,3 +1,4 @@
 <!-- insert_before "erb[loud]:contains('layouts/decidim/admin/application')" -->
 
+<%= append_stylesheet_pack_tag("decidim_homepage_proposals_admin") %>
 <%= append_javascript_pack_tag("decidim_homepage_proposals_admin") %>

--- a/app/packs/entrypoints/decidim_homepage_proposals_admin.js
+++ b/app/packs/entrypoints/decidim_homepage_proposals_admin.js
@@ -1,1 +1,4 @@
 import "src/decidim/homepage_proposals/admin"
+
+// CSS
+import "stylesheets/decidim/homepage_proposals/content_block_settings_extensions.scss"

--- a/app/packs/src/decidim/homepage_proposals/admin.js
+++ b/app/packs/src/decidim/homepage_proposals/admin.js
@@ -1,3 +1,17 @@
+import TomSelect from "tom-select/dist/cjs/tom-select.popular";
+
+document.addEventListener("DOMContentLoaded", () => {
+  const config = {
+    plugins: ["remove_button", "dropdown_input"],
+    allowEmptyOption: true
+  };
+  const linkedComponentsMultiselectContainers = document.querySelectorAll(
+    ".js-linked-components-multiselect"
+  );
+
+  linkedComponentsMultiselectContainers.forEach((container) => new TomSelect(container, config));
+});
+
 $(document).ready(function() {
     $('#content_block_settings_linked_components_id').on('change', function() {
         var selectedOptions = $(this).val(); // Get the selected options from the multiselect field

--- a/app/packs/src/decidim/homepage_proposals/admin.js
+++ b/app/packs/src/decidim/homepage_proposals/admin.js
@@ -16,6 +16,7 @@ $(document).ready(function() {
     $('#content_block_settings_linked_components_id').on('change', function() {
         var selectedOptions = $(this).val(); // Get the selected options from the multiselect field
         var $selectedOptionsField = $('#content_block_settings_default_linked_component'); // Get the select field for the selected options
+        const $defaultLinkedComponentRow = $("[data-default-linked-component-row]");
 
         $selectedOptionsField.empty(); // Clear the select field
 
@@ -25,6 +26,11 @@ $(document).ready(function() {
                 var optionText = $('#content_block_settings_linked_components_id option[value="' + option + '"]').text();
                 $selectedOptionsField.append($('<option>', { value: option, text: optionText }));
             });
+          if (selectedOptions.length == 1) {
+            $defaultLinkedComponentRow.hide();
+          } else {
+            $defaultLinkedComponentRow.show();
+          }
         }
     });
 });

--- a/app/packs/src/decidim/homepage_proposals/glidejs/Manager.js
+++ b/app/packs/src/decidim/homepage_proposals/glidejs/Manager.js
@@ -29,29 +29,19 @@ export default class Manager {
         return 'proposals_slider/filters' + this.filterURIParams();
     }
 
-    displayParam(name) {
-        const field = this.$formFilter.find("input[data-display-config]").filter(`#filter_config_${name}`)
-
-        if (field.length > 0) {
-            return field[0].value === "true";
-        }
-        return false;
-    }
-
     // @return String - Filter params query string
     filterURIParams() {
         const filterForm = this.$formFilter;
         const formAction = filterForm.attr("action");
         const params = filterForm.find("select:not(.ignore-filter)").serialize();
         const configParams = filterForm.find("input[data-filter-config]").serialize();
-        const displayParams = filterForm.find("input[data-display-config]").serialize();
 
         let path = "";
 
         if (formAction.indexOf("?") < 0) {
-            path = `${formAction}?${params}&${configParams}&${displayParams}`;
+            path = `${formAction}?${params}&${configParams}`;
         } else {
-            path = `${formAction}&${params}&${configParams}&${displayParams}`;
+            path = `${formAction}&${params}&${configParams}`;
         }
         return path;
     }
@@ -146,9 +136,6 @@ export default class Manager {
     // @return void
     createProposals(proposals) {
         for (let i = 0; i < proposals.length; i++) {
-            proposals[i]["display_state"] = this.displayParam("state");
-            proposals[i]["display_body"] = this.displayParam("body");
-            proposals[i]["display_image"] = this.displayParam("image");
 
             let proposalGlide = new Proposal(proposals[i])
             this.$proposalsGlideItems.append(proposalGlide.render());

--- a/app/packs/src/decidim/homepage_proposals/glidejs/Manager.js
+++ b/app/packs/src/decidim/homepage_proposals/glidejs/Manager.js
@@ -25,6 +25,10 @@ export default class Manager {
         return '/proposals_slider/refresh_proposals' + this.filterURIParams();
     }
 
+    FilterUrl() {
+        return 'proposals_slider/filters' + this.filterURIParams();
+    }
+
     // @return String - Filter params query string
     filterURIParams() {
         const filterForm = this.$formFilter;

--- a/app/packs/src/decidim/homepage_proposals/glidejs/Manager.js
+++ b/app/packs/src/decidim/homepage_proposals/glidejs/Manager.js
@@ -29,19 +29,29 @@ export default class Manager {
         return 'proposals_slider/filters' + this.filterURIParams();
     }
 
+    displayParam(name) {
+        const field = this.$formFilter.find("input[data-display-config]").filter(`#filter_config_${name}`)
+
+        if (field.length > 0) {
+            return field[0].value === "true";
+        }
+        return false;
+    }
+
     // @return String - Filter params query string
     filterURIParams() {
         const filterForm = this.$formFilter;
         const formAction = filterForm.attr("action");
         const params = filterForm.find("select:not(.ignore-filter)").serialize();
         const configParams = filterForm.find("input[data-filter-config]").serialize();
+        const displayParams = filterForm.find("input[data-display-config]").serialize();
 
         let path = "";
 
         if (formAction.indexOf("?") < 0) {
-            path = `${formAction}?${params}&${configParams}`;
+            path = `${formAction}?${params}&${configParams}&${displayParams}`;
         } else {
-            path = `${formAction}&${params}&${configParams}`;
+            path = `${formAction}&${params}&${configParams}&${displayParams}`;
         }
         return path;
     }
@@ -136,6 +146,10 @@ export default class Manager {
     // @return void
     createProposals(proposals) {
         for (let i = 0; i < proposals.length; i++) {
+            proposals[i]["display_state"] = this.displayParam("state");
+            proposals[i]["display_description"] = this.displayParam("description");
+            proposals[i]["display_image"] = this.displayParam("image");
+
             let proposalGlide = new Proposal(proposals[i])
             this.$proposalsGlideItems.append(proposalGlide.render());
             this.$glideBullets.find(".glide__bullet:last").before(proposalGlide.bullet(i));

--- a/app/packs/src/decidim/homepage_proposals/glidejs/Manager.js
+++ b/app/packs/src/decidim/homepage_proposals/glidejs/Manager.js
@@ -147,7 +147,7 @@ export default class Manager {
     createProposals(proposals) {
         for (let i = 0; i < proposals.length; i++) {
             proposals[i]["display_state"] = this.displayParam("state");
-            proposals[i]["display_description"] = this.displayParam("description");
+            proposals[i]["display_body"] = this.displayParam("body");
             proposals[i]["display_image"] = this.displayParam("image");
 
             let proposalGlide = new Proposal(proposals[i])

--- a/app/packs/src/decidim/homepage_proposals/glidejs/glideItems/NotFound.js
+++ b/app/packs/src/decidim/homepage_proposals/glidejs/glideItems/NotFound.js
@@ -3,18 +3,13 @@ import GlideItem from "./GlideItem";
 export default class NotFound extends GlideItem {
     render() {
         return `<div class="column glide__slide">
-<div class="card card--proposal card--stack">    
+<div class="card card--proposal card--stack">
   <div class="card--header"></div>
     <div class="card--content text-center margin-top-1">
-        <h3 class="card__title">No match</h3>
-        <div class="card__text--paragraph padding-top-1">
-            <p>No proposals found for this request</p>
-        </div>
-        <a href="${this.url}" class="button--clear-filters">
-            <div class="card__button align-bottom">
-                <span class="button button--secondary">Visit proposals</span>
-            </div>
-        </a>
+      <h3 class="card__title">No match</h3>
+      <div class="card__text--paragraph padding-top-1">
+        <p>No proposals found for this request</p>
+      </div>
     </div>
   </div>
 </div>`

--- a/app/packs/src/decidim/homepage_proposals/glidejs/glideItems/Proposal.js
+++ b/app/packs/src/decidim/homepage_proposals/glidejs/glideItems/Proposal.js
@@ -12,7 +12,7 @@ export default class Proposal extends GlideItem {
         this.style = obj.state_css_style;
         this.tags = obj.tags;
         this.displayState = obj.display_state;
-        this.displayDescription = obj.display_description;
+        this.displayBody = obj.display_body;
         this.displayImage = obj.display_image;
     }
 
@@ -29,7 +29,7 @@ export default class Proposal extends GlideItem {
         ${this.statePartial()}
         ${this.titlePartial()}
         ${this.getTagsTemplate()}
-        ${this.descriptionPartial()}
+        ${this.bodyPartial()}
       </div>
     </a>`
     }
@@ -47,8 +47,8 @@ export default class Proposal extends GlideItem {
         }
     }
 
-    descriptionPartial() {
-        if (this.displayDescription) {
+    bodyPartial() {
+        if (this.displayBody) {
             return `<p>${this.body}</p>`;
         } else {
             return "";

--- a/app/packs/src/decidim/homepage_proposals/glidejs/glideItems/Proposal.js
+++ b/app/packs/src/decidim/homepage_proposals/glidejs/glideItems/Proposal.js
@@ -3,17 +3,23 @@ import GlideItem from "./GlideItem";
 export default class Proposal extends GlideItem {
     constructor(obj) {
         super();
+        this.displayBody = obj.hasOwnProperty("body");
+        this.displayImage = obj.hasOwnProperty("image");
+        this.displayState = obj.hasOwnProperty("state_i18n");
         this.title = obj.title;
-        this.body = obj.body;
-        this.image = obj.image;
+        if (this.displayBody) {
+            this.body = obj.body;
+        }
+        if (this.displayImage) {
+            this.image = obj.image;
+        }
         this.url = obj.url;
-        this.stateI18n = obj.state_i18n;
-        this.color = obj.state_css_class;
-        this.style = obj.state_css_style;
+        if (this.displayState) {
+            this.stateI18n = obj.state_i18n;
+            this.color = obj.state_css_class;
+            this.style = obj.state_css_style;
+        }
         this.tags = obj.tags;
-        this.displayState = obj.display_state;
-        this.displayBody = obj.display_body;
-        this.displayImage = obj.display_image;
     }
 
     getTagsTemplate() {

--- a/app/packs/src/decidim/homepage_proposals/glidejs/glideItems/Proposal.js
+++ b/app/packs/src/decidim/homepage_proposals/glidejs/glideItems/Proposal.js
@@ -11,6 +11,9 @@ export default class Proposal extends GlideItem {
         this.color = obj.state_css_class;
         this.style = obj.state_css_style;
         this.tags = obj.tags;
+        this.displayState = obj.display_state;
+        this.displayDescription = obj.display_description;
+        this.displayImage = obj.display_image;
     }
 
     getTagsTemplate() {
@@ -21,20 +24,45 @@ export default class Proposal extends GlideItem {
 
     render() {
         return `<a href="${this.url}" class="card__grid glide__slide">
-      <div class="card__grid-img">
-        ${this.image}
-      </div>
+      ${this.imagePartial()}
       <div class="card__grid-text">
-        <div class="card__list-metadata">
-          <span class="label ${this.color}" style="${this.style}"> ${this.stateI18n} </span>
-        </div>
-        <h3 class="h4 text-secondary">${this.title}</h3>
-
-          ${this.getTagsTemplate()}
-        <p>${this.body}</p>
-
+        ${this.statePartial()}
+        ${this.titlePartial()}
+        ${this.getTagsTemplate()}
+        ${this.descriptionPartial()}
       </div>
     </a>`
+    }
+
+    titlePartial() {
+        return `<h3 class="h4 text-secondary">${this.title}</h3>`;
+    }
+    imagePartial() {
+        if (this.displayImage) {
+            return `<div class="card__grid-img">
+        ${this.image}
+      </div>`;
+        } else {
+            return "";
+        }
+    }
+
+    descriptionPartial() {
+        if (this.displayDescription) {
+            return `<p>${this.body}</p>`;
+        } else {
+            return "";
+        }
+    }
+
+    statePartial() {
+        if (this.displayState) {
+            return `<div class="card__list-metadata">
+          <span class="label ${this.color}" style="${this.style}"> ${this.stateI18n} </span>
+        </div>`
+        } else {
+            return "";
+        }
     }
 
 }

--- a/app/packs/src/decidim/homepage_proposals/glidejs/glideItems/Proposal.js
+++ b/app/packs/src/decidim/homepage_proposals/glidejs/glideItems/Proposal.js
@@ -7,9 +7,9 @@ export default class Proposal extends GlideItem {
         this.body = obj.body;
         this.image = obj.image;
         this.url = obj.url;
-        this.state = obj.state || 'not answered' ;
         this.stateI18n = obj.state_i18n;
         this.color = obj.state_css_class;
+        this.style = obj.state_css_style;
         this.tags = obj.tags;
     }
 
@@ -26,7 +26,7 @@ export default class Proposal extends GlideItem {
       </div>
       <div class="card__grid-text">
         <div class="card__list-metadata">
-          <span class="label ${this.color}"> ${this.stateI18n} </span>
+          <span class="label ${this.color}" style="${this.style}"> ${this.stateI18n} </span>
         </div>
         <h3 class="h4 text-secondary">${this.title}</h3>
 

--- a/app/packs/src/decidim/homepage_proposals/main.js
+++ b/app/packs/src/decidim/homepage_proposals/main.js
@@ -28,6 +28,14 @@ $("[data-proposals-slider]").each((_i, elem) => {
                 const filtersContainerReplacement = div.querySelector("[data-filters-container]");
                 filtersContainer.replaceWith(filtersContainerReplacement)
 
+                const viewAllUrlConfig = div.querySelector("input[data-view-all-url-config]").dataset.viewAllUrlConfig;
+
+                if (viewAllUrlConfig !== undefined) {
+                    const viewAllLink = document.querySelector(`[data-proposals-slider='${slider.sliderId}'] [data-view-all-link]`);
+                    if (viewAllLink) {
+                        viewAllLink.setAttribute("href", viewAllUrlConfig);
+                    }
+                }
                 div.remove();
             });
     });

--- a/app/packs/src/decidim/homepage_proposals/main.js
+++ b/app/packs/src/decidim/homepage_proposals/main.js
@@ -16,7 +16,19 @@ $("[data-proposals-slider]").each((_i, elem) => {
     slider.start()
 
     // Refresh slider when Desktop filter form changes
-    $filterForm.on("change", () => {
-        slider.start()
+    $filterForm.on("change", (event) => {
+        slider.start();
+
+        $.get(slider.FilterUrl())
+            .done((res) => {
+                const div = document.createElement("div");
+                const filtersContainer = slider.$formFilter.find("[data-filters-container]")
+
+                div.innerHTML = res;
+                const filtersContainerReplacement = div.querySelector("[data-filters-container]");
+                filtersContainer.replaceWith(filtersContainerReplacement)
+
+                div.remove();
+            });
     });
 });

--- a/app/packs/stylesheets/decidim/homepage_proposals/content_block_settings_extensions.scss
+++ b/app/packs/stylesheets/decidim/homepage_proposals/content_block_settings_extensions.scss
@@ -1,1 +1,7 @@
 @import "tom-select/dist/scss/tom-select";
+
+[data-default-linked-component-row] {
+  .help-text {
+    @apply text-alert;
+  }
+}

--- a/app/packs/stylesheets/decidim/homepage_proposals/content_block_settings_extensions.scss
+++ b/app/packs/stylesheets/decidim/homepage_proposals/content_block_settings_extensions.scss
@@ -1,0 +1,1 @@
+@import "tom-select/dist/scss/tom-select";

--- a/app/packs/stylesheets/decidim/homepage_proposals/homepage_proposals.scss
+++ b/app/packs/stylesheets/decidim/homepage_proposals/homepage_proposals.scss
@@ -45,7 +45,7 @@
 }
 
 .flex-v-center {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: space-between;
 }

--- a/app/queries/decidim/proposals/slider_proposals.rb
+++ b/app/queries/decidim/proposals/slider_proposals.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    # A class used to find proposals filtered by components and a date range
+    class SliderProposals < Decidim::Query
+      def self.for(components)
+        new(components).query
+      end
+
+      def initialize(components)
+        @components = components
+      end
+
+      def query
+        with_state_not_rejected.or(without_state_not_answered)
+      end
+
+      private
+
+      def with_state_not_rejected
+        base_join.where.not(decidim_proposals_proposal_states: { token: :rejected })
+      end
+
+      def without_state_not_answered
+        base_join.where(decidim_proposals_proposal_state_id: nil, answered_at: nil)
+      end
+
+      def base_join
+        FilteredProposals.for(@components).not_withdrawn.published.left_outer_joins(:proposal_state)
+      end
+    end
+  end
+end

--- a/app/views/decidim/proposals_slider/filters.html.erb
+++ b/app/views/decidim/proposals_slider/filters.html.erb
@@ -1,0 +1,1 @@
+<%= cell("/decidim/homepage_proposals/content_blocks/proposals_slider", @content_block).filters.html_safe %>

--- a/app/views/decidim/shared/homepage_proposals/_filters.erb
+++ b/app/views/decidim/shared/homepage_proposals/_filters.erb
@@ -25,20 +25,8 @@
       </div>
     </div>
   </div>
-  <div class="row">
-    <div class="columns medium-3">
-      <div class="clear-filters">
-        <%= link_to t("decidim.homepage_proposals.proposal_at_a_glance.filters.clear_filters"), decidim_participatory_processes_path(anchor: "proposals-slider-#{model.id}"), class: "button button--secondary small button--sc" %>
-      </div>
-    </div>
-    <div class="columns medium-3">
-      <div class="all-proposals flex-justify-end">
-        <%= link_to view_all_text_config, view_all_url_config, class: "button button--secondary small button--sc" %>
-      </div>
-    </div>
-  </div>
 
   <%= hidden_field_tag("filter_config[order]", order_config, data: { filter_config: "" }) %>
   <%= hidden_field_tag("filter_config[max_results]", max_results_config, data: { filter_config: "" }) %>
-  <%= hidden_field_tag("filter_config[content_block]", data[:proposals_slider], data: { filter_config: "" }) %>
+  <%= hidden_field_tag("filter_config[content_block]", data[:proposals_slider], data: { filter_config: "", view_all_url_config: }) %>
 <% end %>

--- a/app/views/decidim/shared/homepage_proposals/_filters.erb
+++ b/app/views/decidim/shared/homepage_proposals/_filters.erb
@@ -1,30 +1,46 @@
 <%= filter_form_for(filter, decidim_participatory_processes_path, id: "filters-form-#{model.id}") do |form| %>
-  <div class="row" data-filters-container>
-    <div class="columns flex-v-center">
-      <p><%= I18n.t("decidim.homepage_proposals.proposal_at_a_glance.filters.intro") %></p>
-      <% if ordered_scopes_descendants_for_select.present? %>
-        <%= scopes_select_field form, :scope_id, root: nil %>
-      <% end %>
-      <p><%= I18n.t("decidim.homepage_proposals.proposal_at_a_glance.filters.about") %></p>
-      <div class="medium-2">
-        <%= form.categories_select :category_id,
-                                   categories_filter,
-                                   disable_parents: false,
-                                   label: false,
-                                   selected: filter.category_id,
-                                   include_blank: t("decidim.homepage_proposals.proposal_at_a_glance.filters.default_categories") %>
-      </div>
-      <p><%= I18n.t("decidim.homepage_proposals.proposal_at_a_glance.filters.in") %></p>
-      <div class="medium-2 large-3">
-        <%= form.select :component_id,
-                        options_for_default_component,
-                        label: false,
-                        selected: filter.component_id,
-                        data: { placeholder: t("decidim.homepage_proposals.proposal_at_a_glance.filters.components") }
-        %>
+  <% filters_presence = {
+       scopes: ordered_scopes_descendants_for_select.present?,
+       categories: categories_filter.exists?,
+       linked_components: linked_components.count > 1
+     }
+  %>
+
+  <% if filters_presence.values.any? %>
+    <div class="row" data-filters-container>
+      <div class="columns flex-v-center">
+        <p><%= I18n.t("decidim.homepage_proposals.proposal_at_a_glance.filters.intro") %></p>
+        <% if filters_presence[:scopes] %>
+          <%= scopes_select_field form, :scope_id, root: nil %>
+        <% end %>
+
+        <% if filters_presence[:categories] %>
+          <p><%= I18n.t("decidim.homepage_proposals.proposal_at_a_glance.filters.about") %></p>
+          <div class="medium-2">
+            <%= form.categories_select :category_id,
+                                       categories_filter,
+                                       disable_parents: false,
+                                       label: false,
+                                       selected: filter.category_id,
+                                       include_blank: t("decidim.homepage_proposals.proposal_at_a_glance.filters.default_categories") %>
+          </div>
+        <% end %>
+
+
+        <% if filters_presence[:linked_components] %>
+          <p><%= I18n.t("decidim.homepage_proposals.proposal_at_a_glance.filters.in") %></p>
+          <div class="medium-2 large-3">
+            <%= form.select :component_id,
+                            options_for_default_component,
+                            label: false,
+                            selected: filter.component_id,
+                            data: { placeholder: t("decidim.homepage_proposals.proposal_at_a_glance.filters.components") }
+            %>
+          </div>
+        <% end %>
       </div>
     </div>
-  </div>
+  <% end %>
 
   <%= hidden_field_tag("filter_config[order]", order_config, data: { filter_config: "" }) %>
   <%= hidden_field_tag("filter_config[max_results]", max_results_config, data: { filter_config: "" }) %>

--- a/app/views/decidim/shared/homepage_proposals/_filters.erb
+++ b/app/views/decidim/shared/homepage_proposals/_filters.erb
@@ -31,7 +31,7 @@
     </div>
     <div class="columns medium-3">
       <div class="all-proposals flex-justify-end">
-        <%= link_to t("decidim.homepage_proposals.proposal_at_a_glance.filters.all_proposals"), default_linked_component_path, class: "button button--secondary small button--sc" %>
+        <%= link_to view_all_text_config, view_all_url_config, class: "button button--secondary small button--sc" %>
       </div>
     </div>
   </div>

--- a/app/views/decidim/shared/homepage_proposals/_filters.erb
+++ b/app/views/decidim/shared/homepage_proposals/_filters.erb
@@ -7,15 +7,18 @@
   %>
 
   <% if filters_presence.values.any? %>
-    <div class="row" data-filters-container>
+    <div class="row text-right" data-filters-container>
       <div class="columns flex-v-center">
-        <p><%= I18n.t("decidim.homepage_proposals.proposal_at_a_glance.filters.intro") %></p>
+        <span><%= I18n.t("decidim.homepage_proposals.proposal_at_a_glance.filters.intro") %></span>
+
         <% if filters_presence[:scopes] %>
-          <%= scopes_select_field form, :scope_id, root: nil %>
+          <div class="pl-4">
+            <%= scopes_select_field form, :scope_id, root: nil, html_options: { class: "ml-4" } %>
+          </div>
         <% end %>
 
         <% if filters_presence[:categories] %>
-          <p><%= I18n.t("decidim.homepage_proposals.proposal_at_a_glance.filters.about") %></p>
+          <span class="px-4"><%= I18n.t("decidim.homepage_proposals.proposal_at_a_glance.filters.about") %></span>
           <div class="medium-2">
             <%= form.categories_select :category_id,
                                        categories_filter,
@@ -28,7 +31,7 @@
 
 
         <% if filters_presence[:linked_components] %>
-          <p><%= I18n.t("decidim.homepage_proposals.proposal_at_a_glance.filters.in") %></p>
+          <span class="px-4"><%= I18n.t("decidim.homepage_proposals.proposal_at_a_glance.filters.in") %></span>
           <div class="medium-2 large-3">
             <%= form.select :component_id,
                             options_for_default_component,

--- a/app/views/decidim/shared/homepage_proposals/_filters.erb
+++ b/app/views/decidim/shared/homepage_proposals/_filters.erb
@@ -40,4 +40,5 @@
 
   <%= hidden_field_tag("filter_config[order]", order_config, data: { filter_config: "" }) %>
   <%= hidden_field_tag("filter_config[max_results]", max_results_config, data: { filter_config: "" }) %>
+  <%= hidden_field_tag("filter_config[content_block]", data[:proposals_slider], data: { filter_config: "" }) %>
 <% end %>

--- a/app/views/decidim/shared/homepage_proposals/_filters.erb
+++ b/app/views/decidim/shared/homepage_proposals/_filters.erb
@@ -42,6 +42,6 @@
   <%= hidden_field_tag("filter_config[max_results]", max_results_config, data: { filter_config: "" }) %>
   <%= hidden_field_tag("filter_config[content_block]", data[:proposals_slider], data: { filter_config: "" }) %>
   <%= hidden_field_tag("filter_config[state]", display_config[:state] , data: { display_config: "" }) %>
-  <%= hidden_field_tag("filter_config[description]", display_config[:description], data: { display_config: "" }) %>
+  <%= hidden_field_tag("filter_config[body]", display_config[:body], data: { display_config: "" }) %>
   <%= hidden_field_tag("filter_config[image]", display_config[:image], data: { display_config: "" }) %>
 <% end %>

--- a/app/views/decidim/shared/homepage_proposals/_filters.erb
+++ b/app/views/decidim/shared/homepage_proposals/_filters.erb
@@ -1,6 +1,6 @@
 <%= filter_form_for(filter, decidim_participatory_processes_path, id: "filters-form-#{model.id}") do |form| %>
   <% filters_presence = {
-       scopes: ordered_scopes_descendants_for_select.present?,
+       scopes: ordered_scopes_descendants_for_select.present? && ordered_scopes_descendants_for_select.count > 1,
        categories: categories_filter.exists?,
        linked_components: linked_components.count > 1
      }

--- a/app/views/decidim/shared/homepage_proposals/_filters.erb
+++ b/app/views/decidim/shared/homepage_proposals/_filters.erb
@@ -1,6 +1,6 @@
 <%= filter_form_for(filter, decidim_participatory_processes_path, id: "filters-form-#{model.id}") do |form| %>
   <% filters_presence = {
-       scopes: ordered_scopes_descendants_for_select.present? && ordered_scopes_descendants_for_select.count > 1,
+       scopes: available_scopes_ids.present?,
        categories: categories_filter.exists?,
        linked_components: linked_components.count > 1
      }
@@ -13,7 +13,13 @@
 
         <% if filters_presence[:scopes] %>
           <div class="pl-4">
-            <%= scopes_select_field form, :scope_id, root: nil, html_options: { class: "ml-4" } %>
+            <%= form.select(
+                  :scope_id,
+                  scopes_for_select,
+                  { label: false, include_blank: t("decidim.homepage_proposals.proposal_at_a_glance.filters.default_scope") },
+                  { class: "ml-4" }
+                )
+            %>
           </div>
         <% end %>
 

--- a/app/views/decidim/shared/homepage_proposals/_filters.erb
+++ b/app/views/decidim/shared/homepage_proposals/_filters.erb
@@ -41,4 +41,7 @@
   <%= hidden_field_tag("filter_config[order]", order_config, data: { filter_config: "" }) %>
   <%= hidden_field_tag("filter_config[max_results]", max_results_config, data: { filter_config: "" }) %>
   <%= hidden_field_tag("filter_config[content_block]", data[:proposals_slider], data: { filter_config: "" }) %>
+  <%= hidden_field_tag("filter_config[state]", display_config[:state] , data: { display_config: "" }) %>
+  <%= hidden_field_tag("filter_config[description]", display_config[:description], data: { display_config: "" }) %>
+  <%= hidden_field_tag("filter_config[image]", display_config[:image], data: { display_config: "" }) %>
 <% end %>

--- a/app/views/decidim/shared/homepage_proposals/_filters.erb
+++ b/app/views/decidim/shared/homepage_proposals/_filters.erb
@@ -1,5 +1,5 @@
 <%= filter_form_for(filter, decidim_participatory_processes_path, id: "filters-form-#{model.id}") do |form| %>
-  <div class="row">
+  <div class="row" data-filters-container>
     <div class="columns flex-v-center">
       <p><%= I18n.t("decidim.homepage_proposals.proposal_at_a_glance.filters.intro") %></p>
       <% if ordered_scopes_descendants_for_select.present? %>

--- a/app/views/decidim/shared/homepage_proposals/_filters.erb
+++ b/app/views/decidim/shared/homepage_proposals/_filters.erb
@@ -2,7 +2,9 @@
   <div class="row">
     <div class="columns flex-v-center">
       <p><%= I18n.t("decidim.homepage_proposals.proposal_at_a_glance.filters.intro") %></p>
-      <%= scopes_select_field form, :scope_id, root: nil %>
+      <% if ordered_scopes_descendants_for_select.present? %>
+        <%= scopes_select_field form, :scope_id, root: nil %>
+      <% end %>
       <p><%= I18n.t("decidim.homepage_proposals.proposal_at_a_glance.filters.about") %></p>
       <div class="medium-2">
         <%= form.categories_select :category_id,

--- a/app/views/decidim/shared/homepage_proposals/_filters.erb
+++ b/app/views/decidim/shared/homepage_proposals/_filters.erb
@@ -41,7 +41,4 @@
   <%= hidden_field_tag("filter_config[order]", order_config, data: { filter_config: "" }) %>
   <%= hidden_field_tag("filter_config[max_results]", max_results_config, data: { filter_config: "" }) %>
   <%= hidden_field_tag("filter_config[content_block]", data[:proposals_slider], data: { filter_config: "" }) %>
-  <%= hidden_field_tag("filter_config[state]", display_config[:state] , data: { display_config: "" }) %>
-  <%= hidden_field_tag("filter_config[body]", display_config[:body], data: { display_config: "" }) %>
-  <%= hidden_field_tag("filter_config[image]", display_config[:image], data: { display_config: "" }) %>
 <% end %>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -20,6 +20,7 @@ ca:
           linked_components_id: Components disponibles al filtre
           max_results: Nombre màxim d'elements a mostrar
           order: Ordena elements per
+          select_components: Selecciona components
           show:
             least_recent: Menys recent
             most_recent: Més recent

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -43,7 +43,7 @@ ca:
           default_components: Tots els components
           default_scope: Veure tots els àmbits
           in: a
-          intro: Veure contringuts de
+          intro: Veure contringuts
           scope: Àmbit
         learn_more: Més
         no_proposals:

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -38,7 +38,6 @@ ca:
           about: sobre
           all_proposals: Veure tot
           categories: Categories
-          clear_filters: Esborra els filtres
           components: Components
           default_categories: Totes les categories
           default_components: Tots els components

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -25,6 +25,8 @@ ca:
             least_recent: Menys recent
             most_recent: Més recent
             random: Aleatori
+          view_all_text: Text de lenllaç de veure tot
+          view_all_url: URL de lenllaç de veure tot
       proposal_at_a_glance:
         filters:
           about: sobre

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -21,6 +21,8 @@ ca:
           display_proposals_image: Mostrar imatge de les propostes
           display_proposals_state: Mostrar estat de les propostes
           linked_components_id: Components disponibles al filtre
+          max_length_of_body: Màxims caràcters del cos (0 per no truncar)
+          max_length_of_title: Màxims caràcters del títol (0 per no truncar)
           max_results: Nombre màxim d'elements a mostrar
           order: Ordena elements per
           select_components: Selecciona components

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -15,6 +15,7 @@ ca:
           search: Cerca
         proposals_slider_settings_form:
           activate_filters: Activa filtres
+          activate_filters_help: Activar filtres per permetre als usuaris triar un component diferent del seleccionat aquí
           block_title: Titol del bloc
           default_linked_component: Component mostrat per defecte
           display_proposals_body: Mostrar cos de les propostes

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -17,7 +17,7 @@ ca:
           activate_filters: Activa filtres
           block_title: Titol del bloc
           default_linked_component: Component mostrat per defecte
-          display_proposals_description: Mostrar descripció de les propostes
+          display_proposals_body: Mostrar cos de les propostes
           display_proposals_image: Mostrar imatge de les propostes
           display_proposals_state: Mostrar estat de les propostes
           linked_components_id: Components disponibles al filtre

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -17,6 +17,9 @@ ca:
           activate_filters: Activa filtres
           block_title: Titol del bloc
           default_linked_component: Component mostrat per defecte
+          display_proposals_description: Mostrar descripció de les propostes
+          display_proposals_image: Mostrar imatge de les propostes
+          display_proposals_state: Mostrar estat de les propostes
           linked_components_id: Components disponibles al filtre
           max_results: Nombre màxim d'elements a mostrar
           order: Ordena elements per

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,7 +43,7 @@ en:
           default_components: All components
           default_scope: All scopes
           in: in
-          intro: I'd like to see elements from
+          intro: I'd like to see elements
           scope: Scope
         learn_more: View more
         no_proposals:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,7 +39,6 @@ en:
           about: about
           all_proposals: View all
           categories: Categories
-          clear_filters: Clear filters
           components: Components
           default_categories: All categories
           default_components: All components

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,9 @@ en:
           activate_filters: Activate filters
           block_title: Block title
           default_linked_component: Component displayed by default
+          display_proposals_description: Display proposals description
+          display_proposals_image: Display proposals image
+          display_proposals_state: Display proposals state
           linked_components_id: Components available in filters
           max_results: Maximum amount of elements to show
           order: Order elements by

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,7 @@ en:
           linked_components_id: Components available in filters
           max_results: Maximum amount of elements to show
           order: Order elements by
+          select_components: Select components
           show:
             least_recent: Least recent
             most_recent: Most recent

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,7 +17,7 @@ en:
           activate_filters: Activate filters
           block_title: Block title
           default_linked_component: Component displayed by default
-          display_proposals_description: Display proposals description
+          display_proposals_body: Display proposals body
           display_proposals_image: Display proposals image
           display_proposals_state: Display proposals state
           linked_components_id: Components available in filters

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,6 +15,7 @@ en:
           search: Search
         proposals_slider_settings_form:
           activate_filters: Activate filters
+          activate_filters_help: Enable filters to allow users to choose a different component than the one selected here
           block_title: Block title
           default_linked_component: Component displayed by default
           display_proposals_body: Display proposals body

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,7 +15,8 @@ en:
           search: Search
         proposals_slider_settings_form:
           activate_filters: Activate filters
-          activate_filters_help: Enable filters to allow users to choose a different component than the one selected here
+          activate_filters_help: Enable filters to allow users to choose a different
+            component than the one selected here
           block_title: Block title
           default_linked_component: Component displayed by default
           display_proposals_body: Display proposals body

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,8 @@ en:
             least_recent: Least recent
             most_recent: Most recent
             random: Random
+          view_all_text: View all link text
+          view_all_url: View all link URL
       proposal_at_a_glance:
         filters:
           about: about

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,8 @@ en:
           display_proposals_image: Display proposals image
           display_proposals_state: Display proposals state
           linked_components_id: Components available in filters
+          max_length_of_body: Maximumn characters of body (0 to not truncate)
+          max_length_of_title: Maximumn characters of title (0 to not truncate)
           max_results: Maximum amount of elements to show
           order: Order elements by
           select_components: Select components

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -20,6 +20,7 @@ es:
           linked_components_id: Componentes disponibles en el filtro
           max_results: Número máximo de elementos a mostrar
           order: Ordena elementos por
+          select_components: Selecciona componentes
           show:
             least_recent: Menos reciente
             most_recent: Más reciente

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -21,6 +21,8 @@ es:
           display_proposals_image: Mostrar imagen de las propuestas
           display_proposals_state: Mostrar estado de las propuestas
           linked_components_id: Componentes disponibles en el filtro
+          max_length_of_body: Máximos caracteres del cuerpo (0 para no truncar)
+          max_length_of_title: Máximos caracteres del título (0 para no truncar)
           max_results: Número máximo de elementos a mostrar
           order: Ordena elementos por
           select_components: Selecciona componentes

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -43,7 +43,7 @@ es:
           default_components: Todos los componentes
           default_scope: Ver todos los ámbitos
           in: en
-          intro: Ver contenidos de
+          intro: Ver contenidos
           scope: Ámbito
         learn_more: Más
         no_proposals:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -17,6 +17,9 @@ es:
           activate_filters: Activa filtros
           block_title: Titulo del bloque
           default_linked_component: Componente mostrado por defecto
+          display_proposals_description: Mostrar descripción de las propuestas
+          display_proposals_image: Mostrar imagen de las propuestas
+          display_proposals_state: Mostrar estado de las propuestas
           linked_components_id: Componentes disponibles en el filtro
           max_results: Número máximo de elementos a mostrar
           order: Ordena elementos por

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -25,6 +25,8 @@ es:
             least_recent: Menos reciente
             most_recent: Más reciente
             random: Aleatorio
+          view_all_text: Texto del enlace de ver todo
+          view_all_url: URL del enlace de ver todo
       proposal_at_a_glance:
         filters:
           about: sobre

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -17,7 +17,7 @@ es:
           activate_filters: Activa filtros
           block_title: Titulo del bloque
           default_linked_component: Componente mostrado por defecto
-          display_proposals_description: Mostrar descripción de las propuestas
+          display_proposals_body: Mostrar cuerpo de las propuestas
           display_proposals_image: Mostrar imagen de las propuestas
           display_proposals_state: Mostrar estado de las propuestas
           linked_components_id: Componentes disponibles en el filtro

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -15,6 +15,7 @@ es:
           search: Busca
         proposals_slider_settings_form:
           activate_filters: Activa filtros
+          activate_filters_help: Activar filtros para permitir a los usuarios elegir un componente diferente al seleccionado aquí
           block_title: Titulo del bloque
           default_linked_component: Componente mostrado por defecto
           display_proposals_body: Mostrar cuerpo de las propuestas

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -38,7 +38,6 @@ es:
           about: sobre
           all_proposals: Ver todo
           categories: Categorías
-          clear_filters: Borra los filtros
           components: Componentes
           default_categories: Todas las categorías
           default_components: Todos los componentes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@
 
 Rails.application.routes.draw do
   get "proposals_slider/refresh_proposals", to: "decidim/proposals_slider#refresh_proposals"
+  get "proposals_slider/filters", to: "decidim/proposals_slider#filters"
 end

--- a/lib/decidim/homepage_proposals/admin_engine.rb
+++ b/lib/decidim/homepage_proposals/admin_engine.rb
@@ -19,6 +19,10 @@ module Decidim
       def load_seed
         nil
       end
+
+      config.to_prepare do
+        Decidim::Admin::ContentBlockCell.include(Decidim::HomepageProposals::Admin::ContentBlockCellCustomization)
+      end
     end
   end
 end

--- a/lib/decidim/homepage_proposals/engine.rb
+++ b/lib/decidim/homepage_proposals/engine.rb
@@ -41,6 +41,8 @@ module Decidim
             settings.attribute :display_proposals_state, type: :boolean, default: true
             settings.attribute :display_proposals_description, type: :boolean, default: true
             settings.attribute :display_proposals_image, type: :boolean, default: true
+            settings.attribute :max_length_of_body, type: :integer, default: 150
+            settings.attribute :max_length_of_title, type: :integer, default: 40
           end
         end
       end

--- a/lib/decidim/homepage_proposals/engine.rb
+++ b/lib/decidim/homepage_proposals/engine.rb
@@ -36,6 +36,8 @@ module Decidim
             settings.attribute :order, type: :string
             settings.attribute :max_results, type: :integer, default: 12
             settings.attribute :block_title, type: :text, translated: true, preview: -> { I18n.t("decidim.homepage_proposals.proposal_at_a_glance.title") }
+            settings.attribute :view_all_text, type: :text, translated: true
+            settings.attribute :view_all_url, type: :text
           end
         end
       end

--- a/lib/decidim/homepage_proposals/engine.rb
+++ b/lib/decidim/homepage_proposals/engine.rb
@@ -38,6 +38,9 @@ module Decidim
             settings.attribute :block_title, type: :text, translated: true, preview: -> { I18n.t("decidim.homepage_proposals.proposal_at_a_glance.title") }
             settings.attribute :view_all_text, type: :text, translated: true
             settings.attribute :view_all_url, type: :text
+            settings.attribute :display_proposals_state, type: :boolean, default: true
+            settings.attribute :display_proposals_description, type: :boolean, default: true
+            settings.attribute :display_proposals_image, type: :boolean, default: true
           end
         end
       end

--- a/lib/decidim/homepage_proposals/engine.rb
+++ b/lib/decidim/homepage_proposals/engine.rb
@@ -33,7 +33,7 @@ module Decidim
             settings.attribute :activate_filters, type: :boolean, default: false
             settings.attribute :linked_components_id, type: :array
             settings.attribute :default_linked_component, type: :integer
-            settings.attribute :order, type: :string
+            settings.attribute :order, type: :string, default: "most_recent"
             settings.attribute :max_results, type: :integer, default: 12
             settings.attribute :block_title, type: :text, translated: true, preview: -> { I18n.t("decidim.homepage_proposals.proposal_at_a_glance.title") }
             settings.attribute :view_all_text, type: :text, translated: true
@@ -56,7 +56,7 @@ module Decidim
               settings.attribute :activate_filters, type: :boolean, default: false
               settings.attribute :linked_components_id, type: :array
               settings.attribute :default_linked_component, type: :integer
-              settings.attribute :order, type: :string
+              settings.attribute :order, type: :string, default: "most_recent"
               settings.attribute :max_results, type: :integer, default: 12
               settings.attribute :block_title, type: :text, translated: true, preview: -> { I18n.t("decidim.homepage_proposals.proposal_at_a_glance.title") }
               settings.attribute :view_all_text, type: :text, translated: true

--- a/lib/decidim/homepage_proposals/engine.rb
+++ b/lib/decidim/homepage_proposals/engine.rb
@@ -45,6 +45,30 @@ module Decidim
             settings.attribute :max_length_of_title, type: :integer, default: 40
           end
         end
+
+        [:participatory_process_homepage, :participatory_process_group_homepage, :assembly_homepage]. each do |scope_name|
+          Decidim.content_blocks.register(scope_name, "#{scope_name}_proposals_slider") do |content_block|
+            content_block.cell = "decidim/homepage_proposals/content_blocks/proposals_slider"
+            content_block.public_name_key = "decidim.homepage_proposals.content_blocks.proposals_slider.name"
+            content_block.settings_form_cell = "decidim/homepage_proposals/content_blocks/proposals_slider_settings_form"
+            content_block.component_manifest_name = "proposals"
+            content_block.settings do |settings|
+              settings.attribute :activate_filters, type: :boolean, default: false
+              settings.attribute :linked_components_id, type: :array
+              settings.attribute :default_linked_component, type: :integer
+              settings.attribute :order, type: :string
+              settings.attribute :max_results, type: :integer, default: 12
+              settings.attribute :block_title, type: :text, translated: true, preview: -> { I18n.t("decidim.homepage_proposals.proposal_at_a_glance.title") }
+              settings.attribute :view_all_text, type: :text, translated: true
+              settings.attribute :view_all_url, type: :text
+              settings.attribute :display_proposals_state, type: :boolean, default: true
+              settings.attribute :display_proposals_body, type: :boolean, default: true
+              settings.attribute :display_proposals_image, type: :boolean, default: true
+              settings.attribute :max_length_of_body, type: :integer, default: 150
+              settings.attribute :max_length_of_title, type: :integer, default: 40
+            end
+          end
+        end
       end
     end
   end

--- a/lib/decidim/homepage_proposals/engine.rb
+++ b/lib/decidim/homepage_proposals/engine.rb
@@ -39,7 +39,7 @@ module Decidim
             settings.attribute :view_all_text, type: :text, translated: true
             settings.attribute :view_all_url, type: :text
             settings.attribute :display_proposals_state, type: :boolean, default: true
-            settings.attribute :display_proposals_description, type: :boolean, default: true
+            settings.attribute :display_proposals_body, type: :boolean, default: true
             settings.attribute :display_proposals_image, type: :boolean, default: true
             settings.attribute :max_length_of_body, type: :integer, default: 150
             settings.attribute :max_length_of_title, type: :integer, default: 40

--- a/lib/decidim/homepage_proposals/version.rb
+++ b/lib/decidim/homepage_proposals/version.rb
@@ -3,11 +3,11 @@
 module Decidim
   module HomepageProposals
     def self.version
-      "3.0.0"
+      "3.1.0"
     end
 
     def self.decidim_version
-      "0.28"
+      "0.29"
     end
   end
 end


### PR DESCRIPTION
This PR updates the version of the homepage proposals module and adds some changes requested in PopulateTools/issues#2083:

* In the admin part:
  * Replaces the select of available components with a tom-select allowing admins to search the components by name
  * Provides in the components select only published components with visible proposals (published proposals not rejected or withdrawn)
  * If the proposals slider content block has a custom title it is used in the content blocks manager index
  * Adds some new customizations:
    * Custom text of the see all link of the content block
    * Custom URL of the see all link of the content block
    * Allows admins to hide some parts of the proposals cards (by default those parts are displayed) and determine the truncation of some texts (Until now these values ​​were preset to 40 for the title and 150 for the body.)
      * State
      * Body
      * Image
      * Maximum title length before truncation (40 chars by default)
      * Maximum body length before truncation (150 chars by default)
* In the front part:
  * If the filter is enabled the categories select is refreshed after any change to display only categories with associated proposals
  * If there are no scopes available the associated select in the filter is hidden
The PR also:
* Adapts the module to the proposals states feature using an association with a new model instead of using an enum for it.
* Extends the declaration of the content block allowing to use it in participatory processes, groups of processes and assemblies in a way that the components available in each block correspond to the components defined in their respective scopes (the proposals components defined on each process, group or assembly).

## Screenshots

Content block settings using tom-select for spaces:
<img width="1167" alt="Screenshot 2025-05-20 at 11 13 01" src="https://github.com/user-attachments/assets/3a664d94-6830-4954-a431-065530a28d39" />


Index of content blocks displaying the custom title of the block:
<img width="1174" alt="Screenshot 2025-05-20 at 11 12 00" src="https://github.com/user-attachments/assets/cbc85739-962e-4b07-99c7-a3886b17ad17" />


Appearance of content block with filter not enabled:
<img width="1218" alt="Screenshot 2025-05-20 at 11 10 52" src="https://github.com/user-attachments/assets/7bd98302-d710-4904-a6b1-612f7fec1a86" />

Appearance of content block with filter enabled:
<img width="1221" alt="Screenshot 2025-05-20 at 11 15 45" src="https://github.com/user-attachments/assets/d9dcb5de-6401-4652-988c-ac2ea5c9ed34" />

Filter refresh:

https://github.com/user-attachments/assets/dffafffe-c125-4134-ba6d-aae28582f0be



